### PR TITLE
fix(search): search.php using old timber code

### DIFF
--- a/search.php
+++ b/search.php
@@ -13,7 +13,12 @@ $templates[] = 'index.twig';
 
 $context = Timber::context();
 
-$context['posts'] = new PostQuery();
+// Get posts from default query.
+global $wp_query;
+
+$posts = Timber::get_posts( $wp_query );
+
+$context['posts'] = $posts;
 
 get_header();
 Timber::render( $templates, $context );


### PR DESCRIPTION
search.php used PostQuery() with on argument, which causes critical error when using the wp search function. Example
www.website.fi/?s= <-- critical WP error.

Updated to use functionality outlined in:
https://timber.github.io/docs/v2/reference/timber-postquery/

Closes #24 